### PR TITLE
don't log skipped tests as fails

### DIFF
--- a/src/SpiraReporter.js
+++ b/src/SpiraReporter.js
@@ -114,6 +114,10 @@ class SpiraReporter {
                 newTestRun.ExecutionStatusId = 2;
                 newTestRun.RunnerMessage = "Test Succeeded";
             }
+            else if (e.status == "pending") {
+                newTestRun.ExecutionStatusId = 3;
+                newTestRun.RunnerMessage = "Test Skipped";
+            }
             else {
                 //1 is failed in Spira
                 newTestRun.ExecutionStatusId = 1;

--- a/src/SpiraReporter.js
+++ b/src/SpiraReporter.js
@@ -115,8 +115,8 @@ class SpiraReporter {
                 newTestRun.RunnerMessage = "Test Succeeded";
             }
             else if (e.status == "pending") {
+                //3 is Not Run in Spira
                 newTestRun.ExecutionStatusId = 3;
-                newTestRun.RunnerMessage = "Test Skipped";
             }
             else {
                 //1 is failed in Spira


### PR DESCRIPTION
Currently if i run a suite in Jest with some tests skipped, they get logged into spira sa fails.
This is both a little inconvenient and false negative.

So i suggest not logging skipped test, by sending ExecutionStatusId = 3 (not run) to spira